### PR TITLE
Fixes in log module

### DIFF
--- a/src/log.c
+++ b/src/log.c
@@ -58,7 +58,7 @@ static void log_print(const char* msg, enum log_type type)
     char* log = log_bake(msg, type);
 
     /* Print */
-    fprintf(out, log);
+    fputs(log, out);
     fprintf(out, "\n");
 
     /* Free allocated space for log after printing */

--- a/src/log.c
+++ b/src/log.c
@@ -57,9 +57,12 @@ static void log_print(const char* msg, enum log_type type)
     /* Create log */
     char* log = log_bake(msg, type);
 
+    /* Append newline to log */
+    log = realloc(log, strlen(log) + 1 /* newline */ + 1 /* terminating char */);
+    strncat(log, "\n", 1);
+
     /* Print */
     fputs(log, out);
-    fprintf(out, "\n");
 
     /* Free allocated space for log after printing */
     free(log);


### PR DESCRIPTION
The log module used `fprintf`to print logs, which is unsafe because the log might contain the `%` character which in turn, may lead to unexpected result if `fprintf` tries to format it.

Also, I reduced the I/O operations to 1.